### PR TITLE
image: update base image to pangeo/pangeo-notebook:2021.02.19

### DIFF
--- a/deployments/l2l/image/Dockerfile
+++ b/deployments/l2l/image/Dockerfile
@@ -5,8 +5,9 @@
 # pangeo-notebook conda package: https://github.com/conda-forge/pangeo-notebook-feedstock/blob/master/recipe/meta.yaml
 #
 # NOTE: pangeo/pangeo-notebook:2021.03.01 bumps JupyterLab 2 to JupyterLab 3
-#       which is likeley quite breaking.
-FROM pangeo/pangeo-notebook:2020.11.18
+#       which is likeley quite breaking. 2021.02.19 is the most recent release
+#       before that.
+FROM pangeo/pangeo-notebook:2021.02.19
 ARG DEBIAN_FRONTEND=noninteractive
 
 USER root


### PR DESCRIPTION
This includes the latest release of dask-distributed, and the PipInstall plugin is part of the latest version at least. Closes #71.

```
    - dask =2021.2.0
    - distributed =2021.2.0
    - dask-kubernetes =0.11.0
    - dask-gateway =0.9.0
```

Here is a relevant segment of versions, of which this image will contain what I list above: https://github.com/conda-forge/pangeo-dask-feedstock/blame/master/recipe/meta.yaml#L13-L14