### PR TITLE
Install learning-2-learn/lfp_tools by on user pod startup

### DIFF
--- a/chart/files/etc/singleuser/k8s-lifecycle-hook-post-start.sh
+++ b/chart/files/etc/singleuser/k8s-lifecycle-hook-post-start.sh
@@ -3,5 +3,12 @@
 # be very robust, a failure leads to failure for the user pod to start. This is
 # also a script very hard to debug because its stdout output is discarded on
 # success and only available on failures which we want to avoid at all cost.
+#
+# k8s lifecycleHooks reference:
+# https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+#
+# I'm not sure appending "|| true" will work to ensure no individual line cause
+# this script to fail. If so, then perhaps this could work:
+# https://stackoverflow.com/questions/64786/error-handling-in-bash
 
-echo "Do nothing."
+pip install git+https://github.com/learning-2-learn/lfp_tools || true


### PR DESCRIPTION
Based on a request in slack by @arokem:

> We'd like to install the master branch of https://github.com/learning-2-learn/lfp_tools every time a user starts the server. I think that could be done?

The script being edited is already setup to run automatically on user pod startup just in case there would be a need for something like this :)

https://github.com/learning-2-learn/l2lhub-deployment/blob/36345ad4f387addabec1dc8daa624a013e199888/deployments/l2l/config/common.yaml#L74-L79