### PR TITLE
fix: ensure large profile has a mem limit higher than requested memory

### DIFF
--- a/deployments/l2l/config/common.yaml
+++ b/deployments/l2l/config/common.yaml
@@ -199,17 +199,17 @@ daskhub:
                       'default': True,
                       'display_name': 'Small',
                       'description': '6GB RAM',
-                      'kubespawner_override': { 'mem_guarantee':' 6G' },
+                      'kubespawner_override': { 'mem_guarantee':' 6G', 'mem_limit':' 12G' },
                   },
                   {
                       'display_name': 'Medium',
                       'description': '12GB RAM',
-                      'kubespawner_override': { 'mem_guarantee': '12G' },
+                      'kubespawner_override': { 'mem_guarantee': '12G', 'mem_limit':' 24G' },
                   },
                   {
                       'display_name': 'Large',
                       'description': '24GB RAM',
-                      'kubespawner_override': { 'mem_guarantee': '24G' },
+                      'kubespawner_override': { 'mem_guarantee': '24G', 'mem_limit':' 48G' },
                   },
               ]
 


### PR DESCRIPTION
We had defaults like this...

```yaml
      cpu:  # defaults for when profile_list is bypassed, for example by user-placeholder pods
        guarantee: 0.5
        limit: 16
      memory:
        guarantee: 6G
        limit: 12G
```

And when we pressed on the Large server, we got an error related to trying to create a resource with a memory guarantee of 24G but a memory limit of 12G. This PR updates the selection options to imply a limit 2x the guarantee.