### PR TITLE
Optimize requested worker memory to fit better on worker nodes

### DIFF
--- a/deployments/l2l/config/common.yaml
+++ b/deployments/l2l/config/common.yaml
@@ -307,7 +307,7 @@ daskhub:
                       "image": options.image,
                       "worker_cores": 0.80 * chosen_worker_cpu,
                       "worker_cores_limit": chosen_worker_cpu,
-                      "worker_memory": "%fG" % (0.92 * chosen_worker_memory),
+                      "worker_memory": "%fG" % (0.90 * chosen_worker_memory),
                       "worker_memory_limit": "%fG" % chosen_worker_memory,
                       "scheduler_extra_pod_labels": extra_labels,
                       "worker_extra_pod_labels": extra_labels,


### PR DESCRIPTION
Improves resource utilization from 75% to 100%. I could draw this conclusion using `kubectl describe node <a worker node that is supposed to be scheduled full with workers>` and finding it was only scheduled with 3 out of the 4 expected workers.

This is an example from a 4 CPU core worker where we should fit 4 worker
pods rather than 3 but failed due to just a tiny bit too high memory
requests.

```
Non-terminated Pods:          (6 in total)
  Namespace                   Name                                                  CPU Requests  CPU Limits  Memory Requests   Memory Limits     AGE
  ---------                   ----                                                  ------------  ----------  ---------------   -------------     ---
  default                     dask-worker-81746791edd54c199e4d04c88ada718b-98228    800m (20%)    1 (25%)     3951369912 (25%)  4294967296 (27%)  4m56s
  default                     dask-worker-81746791edd54c199e4d04c88ada718b-lqcxn    800m (20%)    1 (25%)     3951369912 (25%)  4294967296 (27%)  4m56s
  default                     dask-worker-81746791edd54c199e4d04c88ada718b-ztzng    800m (20%)    1 (25%)     3951369912 (25%)  4294967296 (27%)  4m56s
  default                     prometheus-node-exporter-kjd5r                        50m (1%)      200m (5%)   30Mi (0%)         50Mi (0%)         3m32s
  kube-system                 aws-node-chmb9                                        10m (0%)      0 (0%)      0 (0%)            0 (0%)            3m32s
  kube-system                 kube-proxy-lgd4l                                      100m (2%)     0 (0%)      0 (0%)            0 (0%)            3m32s
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                    Requests           Limits
  --------                    --------           ------
  cpu                         2560m (65%)        3200m (81%)
  memory                      11885567016 (76%)  12937330688 (83%)
  ephemeral-storage           0 (0%)             0 (0%)
  hugepages-1Gi               0 (0%)             0 (0%)
  hugepages-2Mi               0 (0%)             0 (0%)
  attachable-volumes-aws-ebs  0                  0
```