### PR TITLE
Remove duplicated jupyterlab launcher entries

### DIFF
--- a/chart/files/etc/singleuser/k8s-lifecycle-hook-post-start.sh
+++ b/chart/files/etc/singleuser/k8s-lifecycle-hook-post-start.sh
@@ -11,6 +11,5 @@
 # this script to fail. If so, then perhaps this could work:
 # https://stackoverflow.com/questions/64786/error-handling-in-bash
 
-source /home/jovyan/.bashrc
-conda activate notebook
-python -m pip install git+https://github.com/learning-2-learn/lfp_tools || true
+# Always install the latest lfp_tools which is in active development
+pip install git+https://github.com/learning-2-learn/lfp_tools || true

--- a/chart/files/usr/local/etc/jupyter/jupyter_notebook_config.py
+++ b/chart/files/usr/local/etc/jupyter/jupyter_notebook_config.py
@@ -14,13 +14,11 @@
 # for example by plotly and itk-jupyter-widgets with 3D things.
 c.NotebookApp.iopub_data_rate_limit = 1e12
 
-# Configuration of nb_conda_kernels that converts conda environments to conda
-# kernels, but only those that are not already listed.
+# Configuration of nb_conda_kernels, which scans conda environments to register
+# jupyter kernels.
 #
 # ref: https://github.com/Anaconda-Platform/nb_conda_kernels
-c.CondaKernelSpecManager.name_format = '{1}'
-# This filter is to avoid having the jupyterlab launcher show a duplicated entry
-# for Python and Octave as there are two duplicated environments, the "base" and
-# "notebook" conda environment. Like this, we only use the "base" environment
-# which should be the same.
-c.CondaKernelSpecManager.env_filter = '"((?!envs/notebook).)*"'
+#
+# The jupyter kernels in the conda environment named "notebook" are detected by
+# default, so we use the env_filter option to not register them twice.
+c.CondaKernelSpecManager.env_filter = ".*envs/notebook.*"

--- a/deployments/l2l/config/common.yaml
+++ b/deployments/l2l/config/common.yaml
@@ -76,6 +76,7 @@ daskhub:
           exec:
             command:
               - "bash"
+              - "--login" # to activate conda environments correctly
               - "/etc/singleuser/k8s-lifecycle-hook-post-start.sh"
       storage:
         storage:


### PR DESCRIPTION
This should fix two things in one go:
1. No more duplication of launcher entries
2. No difference between launcher entries: the Python 3 launcher entry that now remains should have lfp_tools installed and available in it