### PR TITLE
Explicitly set ~/.ssh file permissions on pod startup

### DIFF
--- a/chart/files/etc/singleuser/k8s-lifecycle-hook-post-start.sh
+++ b/chart/files/etc/singleuser/k8s-lifecycle-hook-post-start.sh
@@ -13,3 +13,11 @@
 
 # Always install the latest lfp_tools which is in active development
 pip install git+https://github.com/learning-2-learn/lfp_tools || true
+
+# Always re-set restrictive permissions on the SSH keys, as our NFS storage
+# setup cause it to have default permissions on pod restart. The reason for
+# having restrictive permissions is that tools will react if they are too high.
+# If a user wants to update these, the user would just need to elevate
+# permissions as an owner of the files first.
+chmod 400 /home/jovyan/.ssh/id_* || true
+chmod 600 /home/jovyan/.ssh/known_hosts || true


### PR DESCRIPTION
Sorry for the slow turnaround @arokem! This should do the trick for the issue you described on Slack where SSH key file permissions needed to be explicitly updated following pod restarts.

A limitation of NFS storage we have currently is that all file permissions are reset on startup, so this is a workaround rather than a sustainable solution in case we have plenty of different files with permissions that should be managed by the user.