### PR TITLE
Update pangeo-notebook: JupyterLab 2 -> 3, Python 3.8 -> 3.9

### DIFF
--- a/deployments/l2l/image/Dockerfile
+++ b/deployments/l2l/image/Dockerfile
@@ -36,20 +36,20 @@ RUN echo "Installing pip packages..." \
     ${NB_PYTHON_PREFIX}/bin/pip install --no-cache-dir --no-binary=h5py \
         bqplot \
             # ref: https://github.com/bqplot/bqplot
-        bycycle==0.1.* \
+        bycycle \
             # ref: https://github.com/bycycle-tools/bycycle
         dpca \
             # ref: https://github.com/machenslab/dPCA
-        fooof==1.0.* \
+        fooof \
             # ref: https://github.com/fooof-tools/fooof, 1.0.0 is out now
         git+https://github.com/ahwillia/tensortools@1790db3975845 \
             # ref: https://github.com/ahwillia/tensortools, pinned to a commit that works on May 17th, 2021
-        git+https://github.com/h5py/h5py.git \
+        h5py \
             # ref: https://github.com/h5py/h5py
             # NOTE: Let h5py install before HDF5Zarr
         git+https://github.com/catalystneuro/HDF5Zarr.git \
             # ref: https://github.com/catalystneuro/HDF5Zarr
-        git+https://github.com/neurodsp-tools/neurodsp@ed82caa2d93606d1500de0997dce962b81bc69eb \
+        neurodsp \
             # ref: https://github.com/neurodsp-tools/neurodsp
         jupyterlab_hdf \
             # NOTE: Currently does not support JupyterLab 3 it seems:

--- a/deployments/l2l/image/Dockerfile
+++ b/deployments/l2l/image/Dockerfile
@@ -83,7 +83,12 @@ RUN echo "Installing pip packages..." \
             # https://xgboost.readthedocs.io/en/latest/
         shap \ 
             # https://github.com/slundberg/shap
-        graspologic \
+        graspologic==0.3.1.dev1346960477 \
+            # Installing 0.3.0 causes an install of matplotlib 3.3.0, which in
+            # turn breaks while installing. This is likely related to
+            # https://github.com/microsoft/graspologic/pull/854 but I'm a bit
+            # confused why we don't install an even newer version of matplotlib.
+            #
             # https://github.com/microsoft/graspologic, as requested by John Ferre
  && echo "Installing pip packages complete!"
 

--- a/deployments/l2l/image/Dockerfile
+++ b/deployments/l2l/image/Dockerfile
@@ -52,11 +52,9 @@ RUN echo "Installing pip packages..." \
         neurodsp \
             # ref: https://github.com/neurodsp-tools/neurodsp
         jupyterlab_hdf \
-            # NOTE: Currently does not support JupyterLab 3 it seems:
-            #       https://github.com/jupyterlab/jupyterlab-hdf5/issues/42
-            # NOTE: Has an associated JupyterLab extension that needs to be
-            #       installed explicitly as of 2021-03-06.
             # ref: https://github.com/jupyterlab/jupyterlab-hdf5
+        lckr-jupyterlab-variableinspector \
+            # ref: https://github.com/lckr/jupyterlab-variableInspector
         line_profiler \
             # ref: https://github.com/pyutils/line_profiler
         mne \
@@ -91,17 +89,6 @@ RUN echo "Installing pip packages..." \
             #
             # https://github.com/microsoft/graspologic, as requested by John Ferre
  && echo "Installing pip packages complete!"
-
-
-
-RUN echo "Installing jupyterlab extensions..." \
-    && export PATH=${NB_PYTHON_PREFIX}/bin:${PATH} \
-    && jupyter labextension install -y --clean \
-        @lckr/jupyterlab_variableinspector \
-        @jupyterlab/hdf5 \
-        bqplot \
- && echo "Installing jupyterlab extensions complete!"
-
 
 
 RUN echo "Enabling jupyter serverextensions..." \

--- a/deployments/l2l/image/Dockerfile
+++ b/deployments/l2l/image/Dockerfile
@@ -4,10 +4,7 @@
 # pangeo/pangeo-notebook tags: https://hub.docker.com/r/pangeo/pangeo-notebook/tags
 # pangeo-notebook conda package: https://github.com/conda-forge/pangeo-notebook-feedstock/blob/master/recipe/meta.yaml
 #
-# NOTE: pangeo/pangeo-notebook:2021.03.01 bumps JupyterLab 2 to JupyterLab 3
-#       which is likeley quite breaking. 2021.02.19 is the most recent release
-#       before that.
-FROM pangeo/pangeo-notebook:2021.02.19
+FROM pangeo/pangeo-notebook:2021.10.19
 ARG DEBIAN_FRONTEND=noninteractive
 
 USER root
@@ -17,7 +14,7 @@ RUN echo "Installing apt-get packages..." \
         gcc \
         nano \
         octave \
-        g++ \ 
+        g++ \
     && rm -rf /var/lib/apt/lists/*
 USER ${NB_USER}
 


### PR DESCRIPTION
For a detailed comparison on what has changed in the base image, see https://github.com/pangeo-data/pangeo-docker-images/compare/2021.02.19...2021.10.19 and press "files changed", then inspect changes in base-notebook/packages.txt for example.

One thing to note is that Python has upgraded from Python 3.8 to Python 3.9, which I think could mean that packages installed with `pip install --home` or similar, that resides on your home directory, could be found to be malfunctional until they are re-installed.

---

With JupyterLab 3, extensions are preferably installed as Python packages that are bundled with some HTML/JS code. With that, I could remove various jupyterlab extension installation steps because that now happens as part of the Python package installation process. I've retained all extensions, to my knowledge during this upgrade.

---

Closes #90 by updating bycycle from 0.1.* to 1.0.0