### PR TITLE
docs: migrate to modern version of jupyter-book config syntax

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,1 +1,2 @@
-- file: index
+format: jb-book
+root: index


### PR DESCRIPTION
I saw a docs build failure merging #91, this should fix it.