### PR TITLE
docs: fix domain name configuration

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -40,3 +40,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build/html
         publish_branch: gh-pages
+        cname: docs.l2l.sundellopensource.com


### PR DESCRIPTION
https://docs.l2l.sundellopensource.com was broken because a CNAME file was removed, as it was no longer retained when pushing updates etc. This configuration resolves it.